### PR TITLE
Add linebreak after every progress output line

### DIFF
--- a/ArcWelder/arc_welder.h
+++ b/ArcWelder/arc_welder.h
@@ -70,7 +70,7 @@ struct arc_welder_progress {
 		stream << ", Current Line: " << lines_processed;
 		stream << ", Points Compressed: " << points_compressed;
 		stream << ", ArcsCreated: " << arcs_created;
-		stream << ", Compression: " << compression_ratio << "% ";
+		stream << ", Compression: " << compression_ratio << "% \n";
 		return stream.str();
 	}
 };


### PR DESCRIPTION
Just a small cosmetic change for progress output, so that updates start at a new line Most likely this only affects debug builds which are very slow, or files which are very large ...