### PR TITLE
First cut at Makefiles for Linux builds

### DIFF
--- a/ArcWelder/Makefile
+++ b/ArcWelder/Makefile
@@ -1,0 +1,6 @@
+all:
+	g++ -c -I../GCodeProcessorLib *.cpp
+
+
+clean:
+	rm -f *.o

--- a/ArcWelderConsole/Makefile
+++ b/ArcWelderConsole/Makefile
@@ -1,0 +1,5 @@
+all:
+	g++ -o ArcWelderConsole -I../GcodeProcessorLib -I../ArcWelder ../GcodeProcessorLib/*.o ../ArcWelder/*.o ArcWelderConsole.cpp
+
+clean:
+	rm -f ArcWelderConsole

--- a/ArcWelderInverseProcessor/Makefile
+++ b/ArcWelderInverseProcessor/Makefile
@@ -1,0 +1,6 @@
+all:
+	g++ -c -I../GcodeProcessorLib/ inverse_processor.cpp
+	g++ -o ArcWelderInverseProcessor -I../GcodeProcessorLib/ ../GcodeProcessorLib/*.o inverse_processor.o ArcWelderInverseProcessor.cpp 
+
+clean:
+	rm -f *.o ArcWelderInverseProcessor

--- a/GcodeProcessorLib/Makefile
+++ b/GcodeProcessorLib/Makefile
@@ -1,0 +1,6 @@
+all:
+	g++ -c *.cpp
+
+
+clean:
+	rm -f *.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all:
+	$(MAKE) -C GcodeProcessorLib all
+	$(MAKE) -C ArcWelder all
+	$(MAKE) -C ArcWelderConsole all
+	$(MAKE) -C ArcWelderInverseProcessor all
+
+clean:
+	$(MAKE) -C GcodeProcessorLib clean
+	$(MAKE) -C ArcWelder clean
+	$(MAKE) -C ArcWelderConsole clean
+	$(MAKE) -C ArcWelderInverseProcessor clean
+
+
+cleanall: clean
+
+
+.PHONY: all clean 


### PR DESCRIPTION
A very basic set of Makefiles to build the ArcWelderConsole binary under Linux.

From the ArcWelderLib directory, call `make all` to build `ArcWelderConsole/ArcWelderConsole` and `ArcWelderInverseProcessor/ArcWelderInverseProcessor`. 

Cleanup object files and binaries by calling `make clean`

ArcWelderTest is currently not included because it requires windows specific `crtdbg.h` header. 